### PR TITLE
fix: enforce node runtime for api routes

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 const schema = z.object({
   username: z.string(),
   password: z.string(),
@@ -8,12 +13,8 @@ const schema = z.object({
 });
 
 export async function POST(req: NextRequest) {
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-  }
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
   const parse = schema.safeParse(body);
   if (!parse.success) {
     return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
@@ -38,4 +39,8 @@ export async function POST(req: NextRequest) {
     maxAge: rememberMe ? 60 * 60 * 24 * 30 : 60 * 60 * 12,
   });
   return res;
+}
+
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
 
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export async function POST() {
   const res = NextResponse.json({ ok: true });
   res.cookies.set({
@@ -12,4 +17,8 @@ export async function POST() {
     maxAge: 0,
   });
   return res;
+}
+
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }

--- a/src/app/api/requests/[id]/status/route.ts
+++ b/src/app/api/requests/[id]/status/route.ts
@@ -1,34 +1,51 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { requestStatusSchema } from '@/lib/schemas';
+import { RequestStatus } from '@prisma/client';
+import { z } from 'zod';
+
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const idSchema = z.string().cuid();
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  const adminToken = process.env.ADMIN_TOKEN;
+  const auth = req.headers.get('authorization') || '';
+  if (!adminToken || auth !== `Bearer ${adminToken}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  const idParse = idSchema.safeParse(params.id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'Invalid "id"' }, { status: 400 });
   }
-  const parse = requestStatusSchema.safeParse(body);
-  if (!parse.success) {
-    return NextResponse.json({ error: 'Invalid' }, { status: 400 });
+  const id = idParse.data;
+
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
+
+  const raw = (body.status || '').toString().toUpperCase() as RequestStatus;
+  if (!Object.values(RequestStatus).includes(raw)) {
+    return NextResponse.json({ error: 'Invalid "status"' }, { status: 400 });
   }
+  const sortIndex = typeof body.sortIndex === 'number' ? body.sortIndex : undefined;
 
   try {
     const updated = await prisma.request.update({
-      where: { id: params.id },
-      data: {
-        status: parse.data.status,
-        sortIndex: parse.data.sortIndex ?? undefined,
-        updatedAt: new Date(),
-      },
+      where: { id },
+      data: { status: raw, sortIndex, updatedAt: new Date() },
     });
     return NextResponse.json(updated);
   } catch {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
+}
+
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }

--- a/src/app/api/requests/reorder/route.ts
+++ b/src/app/api/requests/reorder/route.ts
@@ -1,25 +1,38 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { reorderSchema } from '@/lib/schemas';
+import { RequestStatus } from '@prisma/client';
+
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 export async function POST(req: NextRequest) {
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  const adminToken = process.env.ADMIN_TOKEN;
+  const auth = req.headers.get('authorization') || '';
+  if (!adminToken || auth !== `Bearer ${adminToken}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const parse = reorderSchema.safeParse(body);
-  if (!parse.success) {
-    return NextResponse.json({ error: 'Invalid' }, { status: 400 });
+
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
+
+  const rawStatus = (body.columnStatus || '').toString().toUpperCase() as RequestStatus;
+  if (!Object.values(RequestStatus).includes(rawStatus)) {
+    return NextResponse.json({ error: 'Invalid "columnStatus"' }, { status: 400 });
+  }
+  const orderedIds = Array.isArray(body.orderedIds)
+    ? (body.orderedIds as unknown[]).filter((id): id is string => typeof id === 'string')
+    : null;
+  if (!orderedIds || orderedIds.length === 0) {
+    return NextResponse.json({ error: 'Invalid "orderedIds"' }, { status: 400 });
   }
 
   try {
     await prisma.$transaction(async (tx) => {
-      for (const [index, id] of parse.data.orderedIds.entries()) {
+      for (const [index, id] of orderedIds.entries()) {
         await tx.request.updateMany({
-          where: { id, status: parse.data.columnStatus },
+          where: { id, status: rawStatus },
           data: { sortIndex: index, updatedAt: new Date() },
         });
       }
@@ -28,4 +41,8 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Database error' }, { status: 500 });
   }
+}
+
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -4,17 +4,26 @@ import { rateLimit } from '@/lib/rate-limit';
 import prisma from '@/lib/prisma';
 import { RequestStatus } from '@prisma/client';
 
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export async function GET(req: NextRequest) {
-  const status = req.nextUrl.searchParams.get('status') as RequestStatus | null;
-  const where = status ? { status } : {};
-  const list = await prisma.request.findMany({
-    where,
-    orderBy: [
-      { sortIndex: 'asc' },
-      { createdAt: 'asc' },
-    ],
-  });
-  return NextResponse.json(list);
+  try {
+    const raw = (req.nextUrl.searchParams.get('status') || '').toUpperCase() as RequestStatus;
+    const where = Object.values(RequestStatus).includes(raw) ? { status: raw } : {};
+    const list = await prisma.request.findMany({
+      where,
+      orderBy: [
+        { sortIndex: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+    return NextResponse.json(list);
+  } catch {
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -22,32 +31,37 @@ export async function POST(req: NextRequest) {
   if (!rateLimit('req:' + ip, 1, 2 * 60 * 1000)) {
     return NextResponse.json({ error: 'Rate limit' }, { status: 429 });
   }
-  const body = await req.json();
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
   const parse = requestSchema.safeParse(body);
   if (!parse.success) {
     return NextResponse.json({ error: 'Invalid' }, { status: 400 });
   }
-  const dup = await prisma.request.findFirst({
-    where: {
-      songTitle: { equals: parse.data.song_title, mode: 'insensitive' },
-      artist: { equals: parse.data.artist, mode: 'insensitive' },
-      status: RequestStatus.PENDING,
-      createdAt: { gte: new Date(Date.now() - 60 * 60 * 1000) },
-    },
-  });
-  if (dup) {
-    await prisma.request.update({
-      where: { id: dup.id },
-      data: { votes: { increment: 1 } },
+  try {
+    const dup = await prisma.request.findFirst({
+      where: {
+        songTitle: { equals: parse.data.song_title, mode: 'insensitive' },
+        artist: { equals: parse.data.artist, mode: 'insensitive' },
+        status: RequestStatus.PENDING,
+        createdAt: { gte: new Date(Date.now() - 60 * 60 * 1000) },
+      },
     });
-    return NextResponse.json({ id: dup.id, duplicate: true });
+    if (dup) {
+      await prisma.request.update({
+        where: { id: dup.id },
+        data: { votes: { increment: 1 } },
+      });
+      return NextResponse.json({ id: dup.id, duplicate: true });
+    }
+    const created = await prisma.request.create({
+      data: {
+        songTitle: parse.data.song_title,
+        artist: parse.data.artist,
+        tableOrName: parse.data.table_or_name,
+      },
+    });
+    return NextResponse.json({ id: created.id });
+  } catch {
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
   }
-  const created = await prisma.request.create({
-    data: {
-      songTitle: parse.data.song_title,
-      artist: parse.data.artist,
-      tableOrName: parse.data.table_or_name,
-    },
-  });
-  return NextResponse.json({ id: created.id });
 }

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -4,31 +4,37 @@ import { rateLimit } from '@/lib/rate-limit';
 import prisma from '@/lib/prisma';
 import crypto from 'crypto';
 
+// Runtime y dinámica para evitar static optimization
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export async function POST(req: NextRequest) {
   const ip = req.ip ?? '0.0.0.0';
-  const body = await req.json();
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
   const parse = voteSchema.safeParse(body);
   if (!parse.success) return NextResponse.json({ error: 'Invalid' }, { status: 400 });
   if (!rateLimit('vote:' + ip + ':' + parse.data.requestId, 1, 24 * 60 * 60 * 1000)) {
     return NextResponse.json({ error: 'Rate limit' }, { status: 429 });
   }
 
-  const reqObj = await prisma.request.findUnique({ where: { id: parse.data.requestId } });
-  if (!reqObj) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-
-  const ipHash = crypto.createHash('sha256').update(ip).digest('hex');
-  const existing = await prisma.vote.findFirst({
-    where: {
-      requestId: parse.data.requestId,
-      ipHash,
-      createdAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) },
-    },
-  });
-  if (existing) {
-    return NextResponse.json({ error: 'Rate limit' }, { status: 429 });
-  }
-
   try {
+    const reqObj = await prisma.request.findUnique({ where: { id: parse.data.requestId } });
+    if (!reqObj) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const ipHash = crypto.createHash('sha256').update(ip).digest('hex');
+    const existing = await prisma.vote.findFirst({
+      where: {
+        requestId: parse.data.requestId,
+        ipHash,
+        createdAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+      },
+    });
+    if (existing) {
+      return NextResponse.json({ error: 'Rate limit' }, { status: 429 });
+    }
+
     await prisma.$transaction([
       prisma.vote.create({ data: { requestId: parse.data.requestId, ipHash } }),
       prisma.request.update({
@@ -41,4 +47,8 @@ export async function POST(req: NextRequest) {
   }
 
   return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }


### PR DESCRIPTION
## Summary
- ensure all API routes run on the Node.js runtime and disable static optimization
- harden request parsing and validate Prisma enums
- protect admin mutations with bearer token auth

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `NODE_ENV=production npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689eb69321cc8320a0544814b69d0b02