### PR TITLE
chore: generate prisma client during build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true
-  }
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- ensure Prisma client is rebuilt during `npm run build`
- clean up `next.config.mjs` from deprecated experimental flag

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689eba4591548320958d189e76d233bf