### PR TITLE
ci: fix rollup optional deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,7 @@ jobs:
           ROLLUP_SKIP_NODEJS_NATIVE: '1'
         run: npm run build
 
-      # Si tu script de test hace "vitest || jest" y no tienes jest, mejor llama vitest directo
       - name: Test
         env:
           ROLLUP_SKIP_NODEJS_NATIVE: '1'
-        run: |
-          if npm run -s test --if-present; then
-            echo "tests ran"
-          else
-            echo "no tests or tests failed"; exit 1
-          fi
+        run: npm run test


### PR DESCRIPTION
## Summary
- reinstall optional deps on CI with `npm install`
- run build and tests with `ROLLUP_SKIP_NODEJS_NATIVE=1`
- ensure test step fails on errors

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ec15387fc8320b1326c77ff5a60e6