### PR TITLE
Fix request form failing due to middleware restriction

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,10 @@ export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const isAdminRoute = pathname.startsWith('/admin');
   const isRequestsRoute = pathname.startsWith('/api/requests');
-  const isPublicRequestsGet =
-    isRequestsRoute && req.method === 'GET' && pathname === '/api/requests';
+  const isPublicRequest =
+    isRequestsRoute && pathname === '/api/requests' && ['GET', 'POST'].includes(req.method);
 
-  if (isPublicRequestsGet) {
+  if (isPublicRequest) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
- Allow public GET and POST access to `/api/requests` in middleware

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3fa4fc1c8320b05a508fc10d0bcd