### PR TITLE
feat: rely on cookie auth for request updates

### DIFF
--- a/src/app/api/requests/[id]/status/route.ts
+++ b/src/app/api/requests/[id]/status/route.ts
@@ -10,16 +10,12 @@ export const revalidate = 0;
 
 const idSchema = z.string().cuid();
 
+// Authorization is enforced by middleware using the admin cookie.
+
 export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const adminToken = process.env.ADMIN_TOKEN;
-  const auth = req.headers.get('authorization') || '';
-  if (!adminToken || auth !== `Bearer ${adminToken}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
   const idParse = idSchema.safeParse(params.id);
   if (!idParse.success) {
     return NextResponse.json({ error: 'Invalid "id"' }, { status: 400 });

--- a/src/app/api/requests/reorder/route.ts
+++ b/src/app/api/requests/reorder/route.ts
@@ -7,13 +7,8 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+// Authorization is enforced by middleware using the admin cookie.
 export async function POST(req: NextRequest) {
-  const adminToken = process.env.ADMIN_TOKEN;
-  const auth = req.headers.get('authorization') || '';
-  if (!adminToken || auth !== `Bearer ${adminToken}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
   const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
   if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
 


### PR DESCRIPTION
## Summary
- rely on middleware cookie auth for request status updates
- rely on middleware cookie auth for request reorder

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `NODE_ENV=production npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f4293fa1c8320b946b27913658caf