### PR TITLE
feat: improve request rate limiting

### DIFF
--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -15,7 +15,8 @@ export async function POST(req: NextRequest) {
   if (!body) return NextResponse.json({ error: 'Bad JSON' }, { status: 400 });
   const parse = voteSchema.safeParse(body);
   if (!parse.success) return NextResponse.json({ error: 'Invalid' }, { status: 400 });
-  if (!rateLimit('vote:' + ip + ':' + parse.data.requestId, 1, 24 * 60 * 60 * 1000)) {
+  const limit = rateLimit('vote:' + ip + ':' + parse.data.requestId, 1, 24 * 60 * 60 * 1000);
+  if (!limit.allowed) {
     return NextResponse.json({ error: 'Rate limit' }, { status: 429 });
   }
 
@@ -42,7 +43,8 @@ export async function POST(req: NextRequest) {
         data: { votes: { increment: 1 } },
       }),
     ]);
-  } catch {
+  } catch (err) {
+    console.error('Error creating vote:', err);
     return NextResponse.json({ error: 'Database error' }, { status: 500 });
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,20 @@ export default function RequestForm() {
         body: JSON.stringify(parsed.data),
       });
       if (!res.ok) {
-        throw new Error('bad status');
+        let message = 'Hubo un problema al enviar tu pedido. Intenta nuevamente.';
+        if (res.status === 429) {
+          const data = (await res.json().catch(() => null)) as {
+            retry_after_seconds?: number;
+          } | null;
+          if (data && typeof data.retry_after_seconds === 'number') {
+            message = `Solo puedes pedir una canción cada 2 minutos. Intenta de nuevo en ${data.retry_after_seconds} segundos.`;
+          } else {
+            message = 'Solo puedes pedir una canción cada 2 minutos. Intenta de nuevo más tarde.';
+          }
+        }
+        setGlobalError(message);
+        setState('idle');
+        return;
       }
       setState('success');
       // opcional: limpiar y redirigir con un pequeño delay para ver el mensaje

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -3,7 +3,10 @@ import { rateLimit } from '../src/lib/rate-limit';
 
 describe('rateLimit', () => {
   it('limits after threshold', () => {
-    expect(rateLimit('a', 1, 1000)).toBe(true);
-    expect(rateLimit('a', 1, 1000)).toBe(false);
+    const first = rateLimit('a', 1, 1000);
+    expect(first.allowed).toBe(true);
+    const second = rateLimit('a', 1, 1000);
+    expect(second.allowed).toBe(false);
+    expect(second.retryAfterMs).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- extend in-memory rate limiter to report remaining time and skip in development
- return `retry_after_seconds` from `/api/requests` and log DB errors
- surface rate limit message on the request form

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f510633ec83208d73e567583618e2