### PR TITLE
Scope request rate limit per user or IP

### DIFF
--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,12 +1,50 @@
 import { describe, it, expect } from 'vitest';
-import { rateLimit } from '../src/lib/rate-limit';
+import { rateLimit, rateLimitByRequest } from '../src/lib/rate-limit';
+import type { NextRequest } from 'next/server';
+import { ADMIN_COOKIE } from '../src/lib/auth';
 
-describe('rateLimit', () => {
-  it('limits after threshold', () => {
-    const first = rateLimit('a', 1, 1000);
-    expect(first.allowed).toBe(true);
-    const second = rateLimit('a', 1, 1000);
-    expect(second.allowed).toBe(false);
-    expect(second.retryAfterMs).toBeGreaterThan(0);
+describe('rate-limit utilities', () => {
+  describe('rateLimit', () => {
+    it('limits after threshold', () => {
+      const first = rateLimit('a', 1, 1000);
+      expect(first.allowed).toBe(true);
+      const second = rateLimit('a', 1, 1000);
+      expect(second.allowed).toBe(false);
+      expect(second.retryAfterMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe('rateLimitByRequest', () => {
+    it('scopes by ip when no user session', () => {
+      const req = {
+        ip: '1.1.1.1',
+        cookies: { get: () => undefined },
+      } as unknown as NextRequest;
+      const first = rateLimitByRequest(req, 'iptest', 1, 1000);
+      expect(first.allowed).toBe(true);
+      const second = rateLimitByRequest(req, 'iptest', 1, 1000);
+      expect(second.allowed).toBe(false);
+    });
+
+    it('scopes by user when session cookie exists', () => {
+      const req = {
+        ip: '1.1.1.1',
+        cookies: {
+          get: (name: string) =>
+            name === ADMIN_COOKIE ? { value: 'user1' } : undefined,
+        },
+      } as unknown as NextRequest;
+      const first = rateLimitByRequest(req, 'usertest', 1, 1000);
+      expect(first.allowed).toBe(true);
+      const req2 = {
+        ip: '2.2.2.2',
+        cookies: {
+          get: (name: string) =>
+            name === ADMIN_COOKIE ? { value: 'user1' } : undefined,
+        },
+      } as unknown as NextRequest;
+      const second = rateLimitByRequest(req2, 'usertest', 1, 1000);
+      expect(second.allowed).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add rateLimitByRequest helper to scope by session cookie or IP
- return Retry-After header and remaining seconds on `/api/requests`
- test user/IP scoped rate limiting

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `NODE_ENV=production npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7d455f808320a5b42a49e8f0c1ad