### PR TITLE
feat: add survey admin CRUD

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model SurveyResponse {
 enum SurveyStatus {
   DRAFT
   PUBLISHED
+  ARCHIVED
 }
 
 enum QuestionType {

--- a/src/app/api/surveys/[id]/route.ts
+++ b/src/app/api/surveys/[id]/route.ts
@@ -1,0 +1,1 @@
+export { GET, PATCH, DELETE } from '@survey/app/api/surveys/[id]/route';

--- a/src/app/api/surveys/route.ts
+++ b/src/app/api/surveys/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from '@survey/app/api/surveys/route';

--- a/src/app/survey/[id]/edit/page.tsx
+++ b/src/app/survey/[id]/edit/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/survey/[id]/edit/page';

--- a/src/app/survey/[id]/results/page.tsx
+++ b/src/app/survey/[id]/results/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/survey/[id]/results/page';

--- a/src/app/survey/new/page.tsx
+++ b/src/app/survey/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/survey/new/page';

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -1,5 +1,1 @@
-import SurveyIndexPage from '@survey/pages/index';
-
-export default function SurveyPage() {
-  return <SurveyIndexPage />;
-}
+export { default } from '@survey/app/survey/page';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,8 @@ export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const isAdminRoute = pathname.startsWith('/dj/admin');
   const isRequestsRoute = pathname.startsWith('/api/requests');
+  const isSurveyRoute = pathname.startsWith('/survey');
+  const isSurveyApiRoute = pathname.startsWith('/api/surveys');
   const isPublicRequest =
     isRequestsRoute && pathname === '/api/requests' && ['GET', 'POST'].includes(req.method);
 
@@ -12,11 +14,11 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  if (isAdminRoute || isRequestsRoute) {
+  if (isAdminRoute || isRequestsRoute || isSurveyRoute || isSurveyApiRoute) {
     if (hasAdminCookie(req)) {
       return NextResponse.next();
     }
-    if (isAdminRoute) {
+    if (isAdminRoute || isSurveyRoute) {
       return NextResponse.redirect(new URL('/dj/login', req.url));
     }
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -26,5 +28,12 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dj/admin', '/dj/admin/:path*', '/api/requests/:path*'],
+  matcher: [
+    '/dj/admin',
+    '/dj/admin/:path*',
+    '/api/requests/:path*',
+    '/survey',
+    '/survey/:path*',
+    '/api/surveys/:path*',
+  ],
 };

--- a/src/modules/survey/app/api/surveys/[id]/route.ts
+++ b/src/modules/survey/app/api/surveys/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { hasAdminCookie } from '@core/api/auth';
+import { SurveyUpsertSchema } from '@survey/lib/validation';
+import { SurveyStatus } from '@prisma/client';
+
+interface Context {
+  params: { id: string };
+}
+
+export async function GET(req: NextRequest, { params }: Context) {
+  if (!hasAdminCookie(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const survey = await prisma.survey.findUnique({
+    where: { id: params.id },
+    include: { questions: true, _count: { select: { responses: true } } },
+  });
+  if (!survey) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(survey);
+}
+
+export async function PATCH(req: NextRequest, { params }: Context) {
+  if (!hasAdminCookie(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parse = SurveyUpsertSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 });
+  }
+  const data = parse.data;
+  try {
+    const updated = await prisma.$transaction(async tx => {
+      await tx.surveyQuestion.deleteMany({ where: { surveyId: params.id } });
+      const survey = await tx.survey.update({
+        where: { id: params.id },
+        data: {
+          name: data.name,
+          slug: data.slug,
+          description: data.description,
+          status: data.status as SurveyStatus,
+          effectiveFrom: data.effectiveFrom,
+          questions: {
+            create: data.questions.map((q, idx) => ({
+              id: q.id,
+              type: q.type,
+              label: q.label,
+              required: q.required ?? false,
+              order: idx,
+              helpText: q.helpText,
+              options: q.options,
+            })),
+          },
+        },
+        include: { questions: true },
+      });
+      return survey;
+    });
+    return NextResponse.json(updated);
+  } catch (err) {
+    console.error('Error updating survey:', err);
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: Context) {
+  if (!hasAdminCookie(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const survey = await prisma.survey.update({
+      where: { id: params.id },
+      data: { status: 'ARCHIVED' },
+    });
+    return NextResponse.json(survey);
+  } catch (err) {
+    console.error('Error deleting survey:', err);
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
+}

--- a/src/modules/survey/app/api/surveys/route.ts
+++ b/src/modules/survey/app/api/surveys/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { hasAdminCookie } from '@core/api/auth';
+import { SurveyUpsertSchema } from '@survey/lib/validation';
+import { Prisma, SurveyStatus } from '@prisma/client';
+
+export async function GET(req: NextRequest) {
+  if (!hasAdminCookie(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = req.nextUrl;
+  const q = searchParams.get('q') || '';
+  const statusRaw = searchParams.get('status')?.toUpperCase() as SurveyStatus | undefined;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '20', 10);
+
+  const where: Prisma.SurveyWhereInput = {};
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: 'insensitive' } },
+      { slug: { contains: q, mode: 'insensitive' } },
+    ];
+  }
+  if (statusRaw && Object.values(SurveyStatus).includes(statusRaw)) {
+    where.status = statusRaw;
+  }
+  if (from || to) {
+    where.updatedAt = {};
+    if (from) where.updatedAt.gte = new Date(from);
+    if (to) where.updatedAt.lte = new Date(to);
+  }
+
+  const [items, total] = await Promise.all([
+    prisma.survey.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { updatedAt: 'desc' },
+      include: { _count: { select: { responses: true } } },
+    }),
+    prisma.survey.count({ where }),
+  ]);
+
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(req: NextRequest) {
+  if (!hasAdminCookie(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parse = SurveyUpsertSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 });
+  }
+  const data = parse.data;
+  try {
+    const created = await prisma.survey.create({
+      data: {
+        name: data.name,
+        slug: data.slug,
+        description: data.description,
+        status: data.status as SurveyStatus,
+        effectiveFrom: data.effectiveFrom,
+        questions: {
+          create: data.questions.map((q, idx) => ({
+            id: q.id,
+            type: q.type,
+            label: q.label,
+            required: q.required ?? false,
+            order: idx,
+            helpText: q.helpText,
+            options: q.options,
+          })),
+        },
+      },
+    });
+    return NextResponse.json(created, { status: 201 });
+  } catch (err) {
+    console.error('Error creating survey:', err);
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
+}

--- a/src/modules/survey/app/survey/[id]/edit/page.tsx
+++ b/src/modules/survey/app/survey/[id]/edit/page.tsx
@@ -1,0 +1,47 @@
+import { cookies } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+import SurveyForm from '@survey/components/SurveyForm';
+import SurveyStatusControls from '@survey/components/SurveyStatusControls';
+import prisma from '@core/prisma';
+import type { Question } from '@survey/lib/validation';
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function EditSurveyPage({ params }: Props) {
+  const cookie = cookies().get('dj_admin');
+  if (cookie?.value !== '1') {
+    redirect('/dj/login');
+  }
+  const survey = await prisma.survey.findUnique({
+    where: { id: params.id },
+    include: { questions: true },
+  });
+  if (!survey) notFound();
+  return (
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Editar encuesta</h1>
+      <SurveyForm
+        initial={{
+          id: survey.id,
+          name: survey.name,
+          slug: survey.slug,
+          description: survey.description,
+          status: survey.status,
+          effectiveFrom: survey.effectiveFrom?.toISOString() ?? null,
+          questions: survey.questions.map(q => ({
+            id: q.id,
+            type: q.type,
+            label: q.label,
+            required: q.required,
+            order: q.order,
+            helpText: q.helpText ?? undefined,
+            options: (q.options as unknown as { label: string; value: string; order: number; id?: string }[]) || undefined,
+          })) as Question[],
+        }}
+      />
+      <SurveyStatusControls id={survey.id} current={survey.status} />
+    </main>
+  );
+}

--- a/src/modules/survey/app/survey/[id]/results/page.tsx
+++ b/src/modules/survey/app/survey/[id]/results/page.tsx
@@ -1,0 +1,68 @@
+import { cookies } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+import prisma from '@core/prisma';
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function SurveyResultsPage({ params }: Props) {
+  const cookie = cookies().get('dj_admin');
+  if (cookie?.value !== '1') {
+    redirect('/dj/login');
+  }
+  const survey = await prisma.survey.findUnique({
+    where: { id: params.id },
+    include: { questions: true },
+  });
+  if (!survey) notFound();
+  const responses = await prisma.surveyResponse.findMany({
+    where: { surveyId: survey.id },
+    orderBy: { createdAt: 'desc' },
+  });
+  const total = responses.length;
+  const recent = responses.filter(r => r.createdAt >= new Date(Date.now() - 24 * 60 * 60 * 1000)).length;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Resultados: {survey.name}</h1>
+      <div className="flex gap-4 mb-4">
+        <div>Total respuestas: {total}</div>
+        <div>Últimas 24h: {recent}</div>
+        <div>Estado: {survey.status}</div>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Fecha</th>
+            {survey.questions.map(q => (
+              <th key={q.id} className="p-2 text-left">{q.label}</th>
+            ))}
+            <th className="p-2 text-left">Ver</th>
+          </tr>
+        </thead>
+        <tbody>
+          {responses.map(r => (
+            <tr key={r.id} className="border-t">
+              <td className="p-2">{r.createdAt.toISOString()}</td>
+              {survey.questions.map(q => {
+                const ans = (r.answers as Record<string, unknown>)[q.id ?? `q${q.order}`];
+                return (
+                  <td key={q.id} className="p-2">
+                    {Array.isArray(ans) ? (ans as unknown[]).join(', ') : String(ans ?? '')}
+                  </td>
+                );
+              })}
+              <td className="p-2">
+                <details>
+                  <summary>ver</summary>
+                  <pre className="whitespace-pre-wrap">{JSON.stringify(r.answers, null, 2)}</pre>
+                </details>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4">TODO: Charts</div>
+    </main>
+  );
+}

--- a/src/modules/survey/app/survey/new/page.tsx
+++ b/src/modules/survey/app/survey/new/page.tsx
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import SurveyForm from '@survey/components/SurveyForm';
+
+export default function NewSurveyPage() {
+  const cookie = cookies().get('dj_admin');
+  if (cookie?.value !== '1') {
+    redirect('/dj/login');
+  }
+  return (
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Nueva encuesta</h1>
+      <SurveyForm />
+    </main>
+  );
+}

--- a/src/modules/survey/app/survey/page.tsx
+++ b/src/modules/survey/app/survey/page.tsx
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import SurveyIndex from '@survey/components/SurveyIndex';
+
+export default function Page() {
+  const cookie = cookies().get('dj_admin');
+  if (cookie?.value !== '1') {
+    redirect('/dj/login');
+  }
+  return (
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Encuestas</h1>
+      <SurveyIndex />
+    </main>
+  );
+}

--- a/src/modules/survey/components/SurveyForm.tsx
+++ b/src/modules/survey/components/SurveyForm.tsx
@@ -1,0 +1,251 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Option {
+  id?: string;
+  label: string;
+  value: string;
+}
+
+interface Question {
+  id?: string;
+  type: string;
+  label: string;
+  required?: boolean;
+  helpText?: string;
+  options?: Option[];
+}
+
+interface SurveyFormProps {
+  initial?: {
+    id?: string;
+    name: string;
+    slug: string;
+    description?: string | null;
+    status: string;
+    effectiveFrom?: string | null;
+    questions: Question[];
+  };
+}
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-');
+
+export default function SurveyForm({ initial }: SurveyFormProps) {
+  const router = useRouter();
+  const [name, setName] = useState(initial?.name || '');
+  const [slug, setSlug] = useState(initial?.slug || '');
+  const [description, setDescription] = useState(initial?.description || '');
+  const [status, setStatus] = useState(initial?.status || 'DRAFT');
+  const [effectiveFrom, setEffectiveFrom] = useState(
+    initial?.effectiveFrom ? initial.effectiveFrom.slice(0, 10) : '',
+  );
+  const [questions, setQuestions] = useState<Question[]>(initial?.questions || []);
+
+  const addQuestion = () => {
+    setQuestions(qs => [
+      ...qs,
+      { type: 'SHORT_TEXT', label: '', required: false, options: [] },
+    ]);
+  };
+
+  const updateQuestion = (idx: number, q: Partial<Question>) => {
+    setQuestions(qs => qs.map((item, i) => (i === idx ? { ...item, ...q } : item)));
+  };
+
+  const removeQuestion = (idx: number) => {
+    setQuestions(qs => qs.filter((_, i) => i !== idx));
+  };
+
+  const moveQuestion = (idx: number, dir: number) => {
+    setQuestions(qs => {
+      const arr = [...qs];
+      const [it] = arr.splice(idx, 1);
+      arr.splice(idx + dir, 0, it);
+      return arr;
+    });
+  };
+
+  const addOption = (qIdx: number) => {
+    setQuestions(qs => {
+      const arr = [...qs];
+      const q = arr[qIdx];
+      q.options = q.options || [];
+      q.options.push({ label: '', value: '' });
+      return arr;
+    });
+  };
+
+  const updateOption = (qIdx: number, oIdx: number, opt: Partial<Option>) => {
+    setQuestions(qs => {
+      const arr = [...qs];
+      const q = arr[qIdx];
+      if (!q.options) q.options = [];
+      q.options[oIdx] = { ...q.options[oIdx], ...opt };
+      return arr;
+    });
+  };
+
+  const removeOption = (qIdx: number, oIdx: number) => {
+    setQuestions(qs => {
+      const arr = [...qs];
+      const q = arr[qIdx];
+      if (q.options) q.options.splice(oIdx, 1);
+      return arr;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      name,
+      slug,
+      description: description || undefined,
+      status,
+      effectiveFrom: effectiveFrom ? new Date(effectiveFrom).toISOString() : undefined,
+      questions: questions.map((q, idx) => ({
+        ...q,
+        order: idx,
+        options: q.options?.map((o, i) => ({ ...o, order: i })),
+      })),
+    };
+    const res = await fetch(initial?.id ? `/api/surveys/${initial.id}` : '/api/surveys', {
+      method: initial?.id ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      router.push('/survey');
+    } else {
+      alert('Error al guardar');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <label className="block">Nombre</label>
+        <input className="border p-2 w-full" value={name} onChange={e => setName(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="block">Slug</label>
+        <div className="flex gap-2">
+          <input className="border p-2 w-full" value={slug} onChange={e => setSlug(e.target.value)} />
+          <button type="button" onClick={() => setSlug(slugify(name))} className="px-2 py-1 border">Auto</button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label className="block">Descripción</label>
+        <textarea className="border p-2 w-full" value={description} onChange={e => setDescription(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="block">Estado</label>
+        <select className="border p-2" value={status} onChange={e => setStatus(e.target.value)}>
+          <option value="DRAFT">DRAFT</option>
+          <option value="PUBLISHED">PUBLISHED</option>
+          <option value="ARCHIVED">ARCHIVED</option>
+        </select>
+      </div>
+      <div className="space-y-2">
+        <label className="block">Vigente desde</label>
+        <input type="date" className="border p-2" value={effectiveFrom} onChange={e => setEffectiveFrom(e.target.value)} />
+      </div>
+
+      <div className="space-y-4">
+        <h2 className="font-bold">Preguntas</h2>
+        {questions.map((q, idx) => (
+          <div key={idx} className="border p-2 space-y-2">
+            <div className="flex justify-between">
+              <span>Pregunta {idx + 1}</span>
+              <div className="space-x-2">
+                {idx > 0 && (
+                  <button type="button" onClick={() => moveQuestion(idx, -1)}>↑</button>
+                )}
+                {idx < questions.length - 1 && (
+                  <button type="button" onClick={() => moveQuestion(idx, 1)}>↓</button>
+                )}
+                <button type="button" onClick={() => removeQuestion(idx)}>Eliminar</button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="block">Tipo</label>
+              <select
+                className="border p-1"
+                value={q.type}
+                onChange={e => updateQuestion(idx, { type: e.target.value })}
+              >
+                <option value="SHORT_TEXT">SHORT_TEXT</option>
+                <option value="LONG_TEXT">LONG_TEXT</option>
+                <option value="EMAIL">EMAIL</option>
+                <option value="PHONE">PHONE</option>
+                <option value="DATE">DATE</option>
+                <option value="SINGLE_CHOICE">SINGLE_CHOICE</option>
+                <option value="MULTIPLE_CHOICE">MULTIPLE_CHOICE</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="block">Etiqueta</label>
+              <input
+                className="border p-1 w-full"
+                value={q.label}
+                onChange={e => updateQuestion(idx, { label: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={q.required || false}
+                  onChange={e => updateQuestion(idx, { required: e.target.checked })}
+                />
+                Requerida
+              </label>
+            </div>
+            {['SINGLE_CHOICE', 'MULTIPLE_CHOICE'].includes(q.type) && (
+              <div className="space-y-2">
+                <h3>Opciones</h3>
+                {q.options?.map((o, oIdx) => (
+                  <div key={oIdx} className="flex gap-2 items-center">
+                    <input
+                      className="border p-1"
+                      placeholder="Label"
+                      value={o.label}
+                      onChange={e =>
+                        updateOption(idx, oIdx, {
+                          label: e.target.value,
+                          value: slugify(e.target.value),
+                        })
+                      }
+                    />
+                    <button type="button" onClick={() => removeOption(idx, oIdx)}>
+                      x
+                    </button>
+                  </div>
+                ))}
+                <button type="button" className="px-2 py-1 border" onClick={() => addOption(idx)}>
+                  Añadir opción
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+        <button type="button" className="px-3 py-1 border" onClick={addQuestion}>
+          Añadir pregunta
+        </button>
+      </div>
+
+      <div className="flex gap-2">
+        <button type="submit" className="px-3 py-1 bg-blue-500 text-white">
+          Guardar
+        </button>
+        <button type="button" className="px-3 py-1 border" onClick={() => router.push('/survey')}>
+          Cancelar
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/modules/survey/components/SurveyIndex.tsx
+++ b/src/modules/survey/components/SurveyIndex.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+
+type SurveyItem = {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  updatedAt: string;
+  _count: { responses: number };
+};
+
+export default function SurveyIndex() {
+  const [list, setList] = useState<SurveyItem[]>([]);
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+
+  const fetchData = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (search) params.set('q', search);
+    if (status) params.set('status', status);
+    if (from) params.set('from', from);
+    if (to) params.set('to', to);
+    const res = await fetch(`/api/surveys?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setList(data.items);
+    }
+  }, [search, status, from, to]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    fetchData();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('¿Archivar encuesta?')) return;
+    await fetch(`/api/surveys/${id}`, { method: 'DELETE' });
+    fetchData();
+  };
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-between">
+        <form onSubmit={handleSearch} className="flex gap-2">
+          <input className="border px-2 py-1" value={search} onChange={e => setSearch(e.target.value)} placeholder="Buscar" />
+          <select className="border px-2 py-1" value={status} onChange={e => setStatus(e.target.value)}>
+            <option value="">Todos</option>
+            <option value="DRAFT">DRAFT</option>
+            <option value="PUBLISHED">PUBLISHED</option>
+            <option value="ARCHIVED">ARCHIVED</option>
+          </select>
+          <input type="date" className="border px-2 py-1" value={from} onChange={e => setFrom(e.target.value)} />
+          <input type="date" className="border px-2 py-1" value={to} onChange={e => setTo(e.target.value)} />
+          <button type="submit" className="px-3 py-1 border">Filtrar</button>
+        </form>
+        <Link href="/survey/new" className="px-3 py-1 border bg-green-500 text-white">Nueva encuesta</Link>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Nombre</th>
+            <th className="p-2 text-left">Slug</th>
+            <th className="p-2 text-left">Estado</th>
+            <th className="p-2 text-left">Actualizado</th>
+            <th className="p-2 text-left">Respuestas</th>
+            <th className="p-2 text-left">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map(it => (
+            <tr key={it.id} className="border-t">
+              <td className="p-2">{it.name}</td>
+              <td className="p-2">{it.slug}</td>
+              <td className="p-2">{it.status}</td>
+              <td className="p-2">{new Date(it.updatedAt).toLocaleString()}</td>
+              <td className="p-2">{it._count.responses}</td>
+              <td className="p-2 flex gap-2">
+                <Link href={`/survey/${it.id}/edit`} className="text-blue-500 underline">Editar</Link>
+                <Link href={`/survey/${it.id}/results`} className="text-blue-500 underline">Resultados</Link>
+                <button onClick={() => navigator.clipboard.writeText(`${window.location.origin}/survey/${it.slug}`)} className="text-blue-500 underline">Copiar enlace</button>
+                <button onClick={() => handleDelete(it.id)} className="text-red-500 underline">Eliminar</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/modules/survey/components/SurveyStatusControls.tsx
+++ b/src/modules/survey/components/SurveyStatusControls.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  id: string;
+  current: string;
+}
+
+export default function SurveyStatusControls({ id, current }: Props) {
+  const router = useRouter();
+  const change = async (status: string) => {
+    await fetch(`/api/surveys/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    router.refresh();
+  };
+  return (
+    <div className="flex gap-2 mt-4">
+      {current !== 'PUBLISHED' && (
+        <button type="button" className="px-2 py-1 border" onClick={() => change('PUBLISHED')}>
+          Publicar
+        </button>
+      )}
+      {current === 'PUBLISHED' && (
+        <button type="button" className="px-2 py-1 border" onClick={() => change('DRAFT')}>
+          Despublicar
+        </button>
+      )}
+      {current !== 'ARCHIVED' && (
+        <button type="button" className="px-2 py-1 border" onClick={() => change('ARCHIVED')}>
+          Archivar
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/modules/survey/lib/validation.ts
+++ b/src/modules/survey/lib/validation.ts
@@ -42,7 +42,7 @@ export const SurveyUpsertSchema = z.object({
   name: z.string().min(1),
   slug: z.string().min(1),
   description: z.string().optional(),
-  status: z.enum(['DRAFT', 'PUBLISHED']).default('DRAFT'),
+  status: z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']).default('DRAFT'),
   effectiveFrom: z.coerce.date().optional(),
   questions: z.array(QuestionSchema),
 });

--- a/src/modules/survey/pages/index.tsx
+++ b/src/modules/survey/pages/index.tsx
@@ -1,8 +1,0 @@
-export default function SurveyIndexPage() {
-  return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold">Surveys</h1>
-      <p>Construcción del módulo de encuestas.</p>
-    </main>
-  );
-}


### PR DESCRIPTION
## Summary
- extend survey status with archived and secure admin routes
- add survey CRUD APIs and admin pages
- include survey builder, filters, and results view

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af52d6abb88320bd51123478f4601e