### PR TITLE
refactor survey form styling

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | false | null>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/modules/survey/app/survey/[id]/edit/page.tsx
+++ b/src/modules/survey/app/survey/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import SurveyForm from '@survey/components/SurveyForm';
 import SurveyStatusControls from '@survey/components/SurveyStatusControls';
 import prisma from '@core/prisma';
 import type { Question } from '@survey/lib/validation';
+import { Card } from '@survey/components/ui';
 
 interface Props {
   params: { id: string };
@@ -31,20 +32,7 @@ export default async function EditSurveyPage({ params }: Props) {
         </div>
       </header>
 
-      <section className="rounded-xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-4 md:p-6 lg:p-8 shadow-lg
-  [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight
-  [&_label]:text-sm [&_label]:font-medium [&_label]:text-foreground
-  [&_small]:text-xs [&_small]:text-muted-foreground
-  [&_fieldset]:space-y-3 [&_fieldset]:border [&_fieldset]:border-white/10 [&_fieldset]:rounded-lg [&_fieldset]:p-4
-  [&_legend]:px-1 [&_legend]:text-xs [&_legend]:uppercase [&_legend]:tracking-wider [&_legend]:text-muted-foreground
-  [&_input]:w-full [&_input]:rounded-md [&_input]:border [&_input]:border-white/10 [&_input]:bg-black/20 [&_input]:px-3 [&_input]:py-2 [&_input]:text-sm [&_input]:text-foreground [&_input]:placeholder:text-muted-foreground [&_input]:shadow-inner focus:[&_input]:outline-none focus:[&_input]:ring-2 focus:[&_input]:ring-primary/50 focus:[&_input]:border-primary/60 disabled:[&_input]:opacity-50
-  [&_textarea]:w-full [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-white/10 [&_textarea]:bg-black/20 [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-sm [&_textarea]:text-foreground [&_textarea]:placeholder:text-muted-foreground [&_textarea]:shadow-inner focus:[&_textarea]:outline-none focus:[&_textarea]:ring-2 focus:[&_textarea]:ring-primary/50 focus:[&_textarea]:border-primary/60 disabled:[&_textarea]:opacity-50
-  [&_select]:w-full [&_select]:rounded-md [&_select]:border [&_select]:border-white/10 [&_select]:bg-black/20 [&_select]:px-3 [&_select]:py-2 [&_select]:text-sm [&_select]:text-foreground [&_select]:shadow-inner focus:[&_select]:outline-none focus:[&_select]:ring-2 focus:[&_select]:ring-primary/50 focus:[&_select]:border-primary/60 disabled:[&_select]:opacity-50
-  [&_input[type='checkbox']]:h-4 [&_input[type='checkbox']]:w-4 [&_input[type='checkbox']]:rounded [&_input[type='checkbox']]:border-white/20
-  [&_hr]:border-white/10
-  [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:rounded-md [&_button]:px-3 [&_button]:py-2 [&_button]:text-sm [&_button]:font-medium [&_button]:transition-colors
-  [&_button.primary]:bg-primary [&_button.primary]:text-primary-foreground hover:[&_button.primary]:bg-primary/90
-  [&_button.muted]:bg-white/10 [&_button.muted]:text-foreground hover:[&_button.muted]:bg-white/15">
+      <Card>
         <SurveyForm
           initial={{
             id: survey.id,
@@ -70,7 +58,7 @@ export default async function EditSurveyPage({ params }: Props) {
             })) as Question[],
           }}
         />
-      </section>
+      </Card>
     </main>
   );
 }

--- a/src/modules/survey/app/survey/new/page.tsx
+++ b/src/modules/survey/app/survey/new/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import SurveyForm from '@survey/components/SurveyForm';
+import { Card } from '@survey/components/ui';
 
 export default function NewSurveyPage() {
   const cookie = cookies().get('dj_admin');
@@ -19,24 +20,9 @@ export default function NewSurveyPage() {
         </div>
       </header>
 
-      <section
-        className="rounded-xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-4 md:p-6 lg:p-8 shadow-lg
-          [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight
-          [&_label]:text-sm [&_label]:font-medium [&_label]:text-foreground
-          [&_small]:text-xs [&_small]:text-muted-foreground
-          [&_fieldset]:space-y-3 [&_fieldset]:border [&_fieldset]:border-white/10 [&_fieldset]:rounded-lg [&_fieldset]:p-4
-          [&_legend]:px-1 [&_legend]:text-xs [&_legend]:uppercase [&_legend]:tracking-wider [&_legend]:text-muted-foreground
-          [&_input]:w-full [&_input]:rounded-md [&_input]:border [&_input]:border-white/10 [&_input]:bg-black/20 [&_input]:px-3 [&_input]:py-2 [&_input]:text-sm [&_input]:text-foreground [&_input]:placeholder:text-muted-foreground [&_input]:shadow-inner focus:[&_input]:outline-none focus:[&_input]:ring-2 focus:[&_input]:ring-primary/50 focus:[&_input]:border-primary/60 disabled:[&_input]:opacity-50
-          [&_textarea]:w-full [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-white/10 [&_textarea]:bg-black/20 [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-sm [&_textarea]:text-foreground [&_textarea]:placeholder:text-muted-foreground [&_textarea]:shadow-inner focus:[&_textarea]:outline-none focus:[&_textarea]:ring-2 focus:[&_textarea]:ring-primary/50 focus:[&_textarea]:border-primary/60 disabled:[&_textarea]:opacity-50
-          [&_select]:w-full [&_select]:rounded-md [&_select]:border [&_select]:border-white/10 [&_select]:bg-black/20 [&_select]:px-3 [&_select]:py-2 [&_select]:text-sm [&_select]:text-foreground [&_select]:shadow-inner focus:[&_select]:outline-none focus:[&_select]:ring-2 focus:[&_select]:ring-primary/50 focus:[&_select]:border-primary/60 disabled:[&_select]:opacity-50
-          [&_input[type='checkbox']]:h-4 [&_input[type='checkbox']]:w-4 [&_input[type='checkbox']]:rounded [&_input[type='checkbox']]:border-white/20
-          [&_hr]:border-white/10
-          [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:rounded-md [&_button]:px-3 [&_button]:py-2 [&_button]:text-sm [&_button]:font-medium [&_button]:transition-colors
-          [&_button.primary]:bg-primary [&_button.primary]:text-primary-foreground hover:[&_button.primary]:bg-primary/90
-          [&_button.muted]:bg-white/10 [&_button.muted]:text-foreground hover:[&_button.muted]:bg-white/15"
-      >
-        <SurveyForm />
-      </section>
+        <Card>
+          <SurveyForm />
+        </Card>
     </main>
   );
 }

--- a/src/modules/survey/components/SurveyForm.tsx
+++ b/src/modules/survey/components/SurveyForm.tsx
@@ -1,6 +1,15 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import {
+  Button,
+  Fieldset,
+  Input,
+  Label,
+  Legend,
+  Select,
+  Textarea,
+} from '@survey/components/ui';
 
 interface Option {
   id?: string;
@@ -128,53 +137,67 @@ export default function SurveyForm({ initial }: SurveyFormProps) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
-        <label className="block">Nombre</label>
-        <input className="border p-2 w-full" value={name} onChange={e => setName(e.target.value)} />
+        <Label htmlFor="name">Nombre</Label>
+        <Input id="name" value={name} onChange={e => setName(e.target.value)} />
       </div>
       <div className="space-y-2">
-        <label className="block">Slug</label>
-        <div className="flex gap-2">
-          <input className="border p-2 w-full" value={slug} onChange={e => setSlug(e.target.value)} />
-          <button type="button" onClick={() => setSlug(slugify(name))} className="px-2 py-1 border">Auto</button>
-        </div>
+          <Label htmlFor="slug">Slug</Label>
+          <div className="flex gap-2">
+            <Input id="slug" value={slug} onChange={e => setSlug(e.target.value)} className="flex-1" />
+            <Button type="button" variant="muted" onClick={() => setSlug(slugify(name))}>
+              Auto
+            </Button>
+          </div>
       </div>
       <div className="space-y-2">
-        <label className="block">Descripción</label>
-        <textarea className="border p-2 w-full" value={description} onChange={e => setDescription(e.target.value)} />
+        <Label htmlFor="description">Descripción</Label>
+        <Textarea id="description" value={description} onChange={e => setDescription(e.target.value)} />
       </div>
       <div className="space-y-2">
-        <label className="block">Estado</label>
-        <select className="border p-2" value={status} onChange={e => setStatus(e.target.value)}>
+        <Label htmlFor="status">Estado</Label>
+        <Select id="status" value={status} onChange={e => setStatus(e.target.value)}>
           <option value="DRAFT">DRAFT</option>
           <option value="PUBLISHED">PUBLISHED</option>
           <option value="ARCHIVED">ARCHIVED</option>
-        </select>
+        </Select>
       </div>
       <div className="space-y-2">
-        <label className="block">Vigente desde</label>
-        <input type="date" className="border p-2" value={effectiveFrom} onChange={e => setEffectiveFrom(e.target.value)} />
+        <Label htmlFor="effectiveFrom">Vigente desde</Label>
+        <Input
+          id="effectiveFrom"
+          type="date"
+          value={effectiveFrom}
+          onChange={e => setEffectiveFrom(e.target.value)}
+        />
       </div>
 
       <div className="space-y-4">
-        <h2 className="font-bold">Preguntas</h2>
+        <h2 className="text-lg font-semibold tracking-tight">Preguntas</h2>
         {questions.map((q, idx) => (
-          <div key={idx} className="border p-2 space-y-2">
+          <Fieldset key={idx} className="space-y-2">
+            <Legend>Pregunta {idx + 1}</Legend>
             <div className="flex justify-between">
               <span>Pregunta {idx + 1}</span>
               <div className="space-x-2">
                 {idx > 0 && (
-                  <button type="button" onClick={() => moveQuestion(idx, -1)}>↑</button>
+                  <Button type="button" variant="muted" onClick={() => moveQuestion(idx, -1)}>
+                    ↑
+                  </Button>
                 )}
                 {idx < questions.length - 1 && (
-                  <button type="button" onClick={() => moveQuestion(idx, 1)}>↓</button>
+                  <Button type="button" variant="muted" onClick={() => moveQuestion(idx, 1)}>
+                    ↓
+                  </Button>
                 )}
-                <button type="button" onClick={() => removeQuestion(idx)}>Eliminar</button>
+                <Button type="button" variant="muted" onClick={() => removeQuestion(idx)}>
+                  Eliminar
+                </Button>
               </div>
             </div>
             <div className="space-y-2">
-              <label className="block">Tipo</label>
-              <select
-                className="border p-1"
+              <Label htmlFor={`q-${idx}-type`}>Tipo</Label>
+              <Select
+                id={`q-${idx}-type`}
                 value={q.type}
                 onChange={e => updateQuestion(idx, { type: e.target.value })}
               >
@@ -185,33 +208,33 @@ export default function SurveyForm({ initial }: SurveyFormProps) {
                 <option value="DATE">DATE</option>
                 <option value="SINGLE_CHOICE">SINGLE_CHOICE</option>
                 <option value="MULTIPLE_CHOICE">MULTIPLE_CHOICE</option>
-              </select>
+              </Select>
             </div>
             <div className="space-y-2">
-              <label className="block">Etiqueta</label>
-              <input
-                className="border p-1 w-full"
+              <Label htmlFor={`q-${idx}-label`}>Etiqueta</Label>
+              <Input
+                id={`q-${idx}-label`}
                 value={q.label}
                 onChange={e => updateQuestion(idx, { label: e.target.value })}
               />
             </div>
             <div className="space-y-2">
-              <label className="inline-flex items-center gap-2">
-                <input
+              <Label htmlFor={`q-${idx}-required`} className="inline-flex items-center gap-2">
+                <Input
+                  id={`q-${idx}-required`}
                   type="checkbox"
                   checked={q.required || false}
                   onChange={e => updateQuestion(idx, { required: e.target.checked })}
                 />
                 Requerida
-              </label>
+              </Label>
             </div>
             {['SINGLE_CHOICE', 'MULTIPLE_CHOICE'].includes(q.type) && (
               <div className="space-y-2">
                 <h3>Opciones</h3>
                 {q.options?.map((o, oIdx) => (
-                  <div key={oIdx} className="flex gap-2 items-center">
-                    <input
-                      className="border p-1"
+                  <div key={oIdx} className="flex items-center gap-2">
+                    <Input
                       placeholder="Label"
                       value={o.label}
                       onChange={e =>
@@ -221,30 +244,28 @@ export default function SurveyForm({ initial }: SurveyFormProps) {
                         })
                       }
                     />
-                    <button type="button" onClick={() => removeOption(idx, oIdx)}>
+                    <Button type="button" variant="muted" onClick={() => removeOption(idx, oIdx)}>
                       x
-                    </button>
+                    </Button>
                   </div>
                 ))}
-                <button type="button" className="px-2 py-1 border" onClick={() => addOption(idx)}>
+                <Button type="button" variant="muted" onClick={() => addOption(idx)}>
                   Añadir opción
-                </button>
+                </Button>
               </div>
             )}
-          </div>
+          </Fieldset>
         ))}
-        <button type="button" className="px-3 py-1 border" onClick={addQuestion}>
+        <Button type="button" variant="muted" onClick={addQuestion}>
           Añadir pregunta
-        </button>
+        </Button>
       </div>
 
       <div className="flex gap-2">
-        <button type="submit" className="px-3 py-1 bg-blue-500 text-white">
-          Guardar
-        </button>
-        <button type="button" className="px-3 py-1 border" onClick={() => router.push('/survey')}>
+        <Button type="submit">Guardar</Button>
+        <Button type="button" variant="muted" onClick={() => router.push('/survey')}>
           Cancelar
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/modules/survey/components/SurveyStatusControls.tsx
+++ b/src/modules/survey/components/SurveyStatusControls.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
+import { Button } from '@survey/components/ui';
 
 interface Props {
   id: string;
@@ -17,21 +18,21 @@ export default function SurveyStatusControls({ id, current }: Props) {
     router.refresh();
   };
   return (
-    <div className="flex gap-2 mt-4">
+    <div className="mt-4 flex gap-2">
       {current !== 'PUBLISHED' && (
-        <button type="button" className="px-2 py-1 border" onClick={() => change('PUBLISHED')}>
+        <Button type="button" variant="muted" onClick={() => change('PUBLISHED')}>
           Publicar
-        </button>
+        </Button>
       )}
       {current === 'PUBLISHED' && (
-        <button type="button" className="px-2 py-1 border" onClick={() => change('DRAFT')}>
+        <Button type="button" variant="muted" onClick={() => change('DRAFT')}>
           Despublicar
-        </button>
+        </Button>
       )}
       {current !== 'ARCHIVED' && (
-        <button type="button" className="px-2 py-1 border" onClick={() => change('ARCHIVED')}>
+        <Button type="button" variant="muted" onClick={() => change('ARCHIVED')}>
           Archivar
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/modules/survey/components/ui/button.tsx
+++ b/src/modules/survey/components/ui/button.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'muted';
+}
+
+const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
+  primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  muted: 'bg-white/10 text-foreground hover:bg-white/15',
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant = 'primary', ...props }, ref) => (
+  <button
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
+      variants[variant],
+      className,
+    )}
+    {...props}
+  />
+));
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/modules/survey/components/ui/card.tsx
+++ b/src/modules/survey/components/ui/card.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Card = ({ className, ...props }: CardProps) => (
+  <div
+    className={cn(
+      'rounded-xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-4 md:p-6 lg:p-8 shadow-lg',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export default Card;

--- a/src/modules/survey/components/ui/fieldset.tsx
+++ b/src/modules/survey/components/ui/fieldset.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type FieldsetProps = React.FieldsetHTMLAttributes<HTMLFieldSetElement>;
+export type LegendProps = React.HTMLAttributes<HTMLLegendElement>;
+
+export const Fieldset = React.forwardRef<HTMLFieldSetElement, FieldsetProps>(({ className, ...props }, ref) => (
+  <fieldset ref={ref} className={cn('space-y-3 rounded-lg border border-white/10 p-4', className)} {...props} />
+));
+Fieldset.displayName = 'Fieldset';
+
+export const Legend = React.forwardRef<HTMLLegendElement, LegendProps>(({ className, ...props }, ref) => (
+  <legend ref={ref} className={cn('px-1 text-xs uppercase tracking-wider text-muted-foreground', className)} {...props} />
+));
+Legend.displayName = 'Legend';

--- a/src/modules/survey/components/ui/index.ts
+++ b/src/modules/survey/components/ui/index.ts
@@ -1,0 +1,7 @@
+export { default as Input } from './input';
+export { default as Textarea } from './textarea';
+export { default as Select } from './select';
+export { default as Label } from './label';
+export { Fieldset, Legend } from './fieldset';
+export { default as Button } from './button';
+export { default as Card } from './card';

--- a/src/modules/survey/components/ui/input.tsx
+++ b/src/modules/survey/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = 'text', ...props }, ref) => {
+  const base =
+    type === 'checkbox'
+      ? 'h-4 w-4 rounded border-white/20'
+      : 'w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground shadow-inner focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/60 disabled:opacity-50';
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cn(base, "aria-[invalid='true']:border-red-400 aria-[invalid='true']:ring-red-400", className)}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/modules/survey/components/ui/label.tsx
+++ b/src/modules/survey/components/ui/label.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+  <label ref={ref} className={cn('text-sm font-medium text-foreground', className)} {...props} />
+));
+Label.displayName = 'Label';
+
+export default Label;

--- a/src/modules/survey/components/ui/select.tsx
+++ b/src/modules/survey/components/ui/select.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ className, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      'w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-foreground shadow-inner focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/60 disabled:opacity-50 aria-[invalid="true"]:border-red-400 aria-[invalid="true"]:ring-red-400',
+      className,
+    )}
+    {...props}
+  />
+));
+Select.displayName = 'Select';
+
+export default Select;

--- a/src/modules/survey/components/ui/textarea.tsx
+++ b/src/modules/survey/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      'w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground shadow-inner focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/60 disabled:opacity-50 aria-[invalid="true"]:border-red-400 aria-[invalid="true"]:ring-red-400',
+      className,
+    )}
+    {...props}
+  />
+));
+Textarea.displayName = 'Textarea';
+
+export default Textarea;


### PR DESCRIPTION
## Summary
- abstract survey form styles into reusable UI components
- simplify survey form pages using shared Card wrapper
- unify status controls and input styling

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Module '@prisma/client' has no exported member 'SurveyStatus')*
- `npm test`
- `npm run build` *(fails: Cannot read properties of null (reading 'useContext'))*


------
https://chatgpt.com/codex/tasks/task_e_68afc33f86148320bdeffa123aaf2b76