### PR TITLE
feat: add survey module navigation layout

### DIFF
--- a/src/app/survey/layout.tsx
+++ b/src/app/survey/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/survey/layout';

--- a/src/modules/survey/app/survey/[id]/edit/page.tsx
+++ b/src/modules/survey/app/survey/[id]/edit/page.tsx
@@ -2,9 +2,12 @@ import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 import SurveyForm from '@survey/components/SurveyForm';
 import SurveyStatusControls from '@survey/components/SurveyStatusControls';
+import Breadcrumbs from '@survey/components/nav/Breadcrumbs';
+import SurveyTabs from '@survey/components/nav/SurveyTabs';
 import prisma from '@core/prisma';
 import type { Question } from '@survey/lib/validation';
 import { Card } from '@survey/components/ui';
+import Link from 'next/link';
 
 interface Props {
   params: { id: string };
@@ -21,7 +24,22 @@ export default async function EditSurveyPage({ params }: Props) {
   });
   if (!survey) notFound();
   return (
-    <main className="mx-auto w-full max-w-[1400px] px-3 md:px-4 lg:px-6 py-5 space-y-6">
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Breadcrumbs
+          items={[
+            { label: 'Inicio', href: '/' },
+            { label: 'Surveys', href: '/survey' },
+            { label: survey.name || survey.id },
+            { label: 'Editar' },
+          ]}
+        />
+        <SurveyTabs id={survey.id} />
+        <Link href="/survey" className="text-sm text-indigo-300 hover:text-indigo-200">
+          ← Volver
+        </Link>
+      </div>
+
       <header className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">Editar encuesta</h1>
@@ -59,6 +77,6 @@ export default async function EditSurveyPage({ params }: Props) {
           }}
         />
       </Card>
-    </main>
+    </div>
   );
 }

--- a/src/modules/survey/app/survey/[id]/results/page.tsx
+++ b/src/modules/survey/app/survey/[id]/results/page.tsx
@@ -1,6 +1,9 @@
 import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 import prisma from '@core/prisma';
+import Breadcrumbs from '@survey/components/nav/Breadcrumbs';
+import SurveyTabs from '@survey/components/nav/SurveyTabs';
+import Link from 'next/link';
 
 interface Props {
   params: { id: string };
@@ -47,7 +50,22 @@ export default async function SurveyResultsPage({ params }: Props) {
   ).length;
 
   return (
-    <main className="mx-auto w-full max-w-7xl p-3">
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Breadcrumbs
+          items={[
+            { label: 'Inicio', href: '/' },
+            { label: 'Surveys', href: '/survey' },
+            { label: survey.name || survey.id },
+            { label: 'Resultados' },
+          ]}
+        />
+        <SurveyTabs id={survey.id} />
+        <Link href="/survey" className="text-sm text-indigo-300 hover:text-indigo-200">
+          ← Volver
+        </Link>
+      </div>
+
       {/* Header */}
       <div className="mb-4">
         <h1 className="text-2xl font-semibold tracking-tight text-slate-100">
@@ -152,6 +170,6 @@ export default async function SurveyResultsPage({ params }: Props) {
         <h2 className="mb-2 text-lg font-medium text-slate-100">Gráficos</h2>
         <p className="text-sm text-slate-400">Próximamente: distribución de respuestas por pregunta.</p>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/modules/survey/app/survey/layout.tsx
+++ b/src/modules/survey/app/survey/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+
+export default function SurveyLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="mx-auto w-full max-w-[1400px] px-3 md:px-4 lg:px-6 py-5 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Encuestas</h1>
+        <Link
+          href="/survey/new"
+          className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500"
+        >
+          Nueva encuesta
+        </Link>
+      </div>
+      {children}
+    </main>
+  );
+}

--- a/src/modules/survey/app/survey/new/page.tsx
+++ b/src/modules/survey/app/survey/new/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import SurveyForm from '@survey/components/SurveyForm';
 import { Card } from '@survey/components/ui';
+import Breadcrumbs from '@survey/components/nav/Breadcrumbs';
 
 export default function NewSurveyPage() {
   const cookie = cookies().get('dj_admin');
@@ -10,7 +11,8 @@ export default function NewSurveyPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-[1400px] px-3 md:px-4 lg:px-6 py-5 space-y-6">
+    <div className="space-y-6">
+      <Breadcrumbs items={[{ label: 'Inicio', href: '/' }, { label: 'Surveys', href: '/survey' }, { label: 'Nueva' }]} />
       <header className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">Nueva encuesta</h1>
@@ -20,9 +22,9 @@ export default function NewSurveyPage() {
         </div>
       </header>
 
-        <Card>
-          <SurveyForm />
-        </Card>
-    </main>
+      <Card>
+        <SurveyForm />
+      </Card>
+    </div>
   );
 }

--- a/src/modules/survey/app/survey/page.tsx
+++ b/src/modules/survey/app/survey/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import Breadcrumbs from '@survey/components/nav/Breadcrumbs';
 
 type SurveyItem = {
   id: string;
@@ -89,9 +90,10 @@ export default function SurveyIndex() {
 
   return (
     <div className="space-y-4">
+      <Breadcrumbs items={[{ label: 'Inicio', href: '/' }, { label: 'Surveys' }]} />
       {/* Filters */}
       <div className="rounded-lg border border-white/10 bg-white/5 p-4 backdrop-blur sm:p-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
           <form onSubmit={handleSearch} className="grid w-full grid-cols-1 gap-3 sm:grid-cols-5">
             <div className="col-span-2">
               <label className="mb-1 block text-xs font-medium text-gray-300">Buscar</label>
@@ -152,13 +154,6 @@ export default function SurveyIndex() {
               </button>
             </div>
           </form>
-
-          <Link
-            href="/survey/new"
-            className="inline-flex shrink-0 items-center justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
-          >
-            Nueva encuesta
-          </Link>
         </div>
       </div>
 

--- a/src/modules/survey/components/nav/Breadcrumbs.tsx
+++ b/src/modules/survey/components/nav/Breadcrumbs.tsx
@@ -1,0 +1,41 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface Crumb {
+  href?: string;
+  label: string;
+}
+
+interface Props {
+  items: Crumb[];
+}
+
+export default function Breadcrumbs({ items }: Props) {
+  const pathname = usePathname();
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1 text-sm text-gray-400">
+        {items.map((item, idx) => {
+          const isLast = idx === items.length - 1;
+          const isActive = isLast || item.href === pathname;
+          const content = item.href && !isLast ? (
+            <Link href={item.href} className="hover:text-gray-200">
+              {item.label}
+            </Link>
+          ) : (
+            <span className={isActive ? 'text-gray-200' : undefined} aria-current={isActive ? 'page' : undefined}>
+              {item.label}
+            </span>
+          );
+          return (
+            <li key={idx} className="flex items-center gap-1">
+              {content}
+              {!isLast && <span className="text-gray-500">›</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/modules/survey/components/nav/SurveyTabs.tsx
+++ b/src/modules/survey/components/nav/SurveyTabs.tsx
@@ -1,0 +1,38 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface Props {
+  id: string;
+}
+
+export default function SurveyTabs({ id }: Props) {
+  const pathname = usePathname();
+  const base = `/survey/${id}`;
+  const tabs = [
+    { href: `${base}/edit`, label: 'Editar' },
+    { href: `${base}/results`, label: 'Resultados' },
+  ];
+  return (
+    <div role="tablist" className="flex border-b border-white/10 text-sm">
+      {tabs.map((tab) => {
+        const active = pathname === tab.href;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            role="tab"
+            aria-selected={active}
+            className={`px-3 py-2 -mb-px border-b-2 ${
+              active
+                ? 'border-indigo-400 text-white'
+                : 'border-transparent text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add layout with persistent survey header
- introduce accessible breadcrumbs and tabs for survey pages
- wire pages to new navigation and back links

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afc6053ec48320ad9bf61af78c1e8a