### PR TITLE
feat: add public survey responses

### DIFF
--- a/src/app/(public)/survey/[id]/loading.tsx
+++ b/src/app/(public)/survey/[id]/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/public/survey/[id]/loading';

--- a/src/app/(public)/survey/[id]/page.tsx
+++ b/src/app/(public)/survey/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@survey/app/public/survey/[id]/page';

--- a/src/app/api/survey/[slug]/route.ts
+++ b/src/app/api/survey/[slug]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@survey/app/api/survey/[slug]/route';

--- a/src/app/api/surveys/[id]/responses/route.ts
+++ b/src/app/api/surveys/[id]/responses/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@survey/app/api/surveys/[id]/responses/route';

--- a/src/modules/survey/app/api/survey/[slug]/route.ts
+++ b/src/modules/survey/app/api/survey/[slug]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse, NextRequest } from 'next/server';
+import prisma from '@core/prisma';
+
+export async function GET(req: NextRequest, { params }: { params: { slug: string } }) {
+  const survey = await prisma.survey.findUnique({
+    where: { slug: params.slug },
+    include: { questions: { orderBy: { order: 'asc' } } },
+  });
+  if (!survey || survey.status !== 'PUBLISHED') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(survey);
+}

--- a/src/modules/survey/app/api/surveys/[id]/responses/route.ts
+++ b/src/modules/survey/app/api/surveys/[id]/responses/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { buildZodFromSurvey, normalizeAnswers, Question } from '@survey/lib/validation';
+import { checkRateLimit } from '@survey/lib/rate-limit';
+import type { Prisma } from '@prisma/client';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const survey = await prisma.survey.findUnique({
+    where: { id: params.id },
+    include: { questions: { orderBy: { order: 'asc' } } },
+  });
+  if (!survey || survey.status !== 'PUBLISHED') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0] ?? '0.0.0.0';
+  const rate = checkRateLimit(`${survey.id}:${ip}`);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfterSeconds: rate.retryAfter },
+      { status: 429 },
+    );
+  }
+
+  const body = await req.json().catch(() => null);
+  const answers = body?.answers ?? {};
+  const schema = buildZodFromSurvey(survey.questions as unknown as Question[]);
+  const parse = schema.safeParse(answers);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 422 });
+  }
+
+  const normalized = normalizeAnswers(parse.data, survey.questions as unknown as Question[]);
+
+  await prisma.surveyResponse.create({
+    data: { surveyId: survey.id, answers: normalized as Prisma.InputJsonValue },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/modules/survey/app/public/survey/[id]/loading.tsx
+++ b/src/modules/survey/app/public/survey/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function LoadingSurvey() {
+  return <p className="p-4 text-center">Cargando encuesta...</p>;
+}

--- a/src/modules/survey/app/public/survey/[id]/page.tsx
+++ b/src/modules/survey/app/public/survey/[id]/page.tsx
@@ -1,0 +1,28 @@
+import Card from '@survey/components/ui/card';
+import PublicSurveyForm from '@survey/components/PublicSurveyForm';
+import prisma from '@core/prisma';
+import { notFound } from 'next/navigation';
+import type { Question } from '@survey/lib/validation';
+
+export default async function SurveyPublicPage({ params }: { params: { id: string } }) {
+  const survey = (await prisma.survey.findUnique({
+    where: { slug: params.id },
+    include: { questions: { orderBy: { order: 'asc' } } },
+  })) as ({
+    id: string;
+    name: string;
+    description: string | null;
+    status: string;
+    questions: Question[];
+  }) | null;
+  if (!survey || survey.status !== 'PUBLISHED') notFound();
+  return (
+    <div className="mx-auto max-w-2xl p-4">
+      <Card>
+        <h1 className="mb-4 text-2xl font-semibold tracking-tight">{survey.name}</h1>
+        {survey.description && <p className="mb-6 text-sm text-muted-foreground">{survey.description}</p>}
+        <PublicSurveyForm survey={survey} />
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/survey/components/PublicSurveyForm.tsx
+++ b/src/modules/survey/components/PublicSurveyForm.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState } from 'react';
+import { Question } from '@survey/lib/validation';
+import { Input, Textarea, Select, Button, Fieldset } from '@survey/components/ui';
+
+interface Props {
+  survey: {
+    id: string;
+    name: string;
+    description?: string | null;
+    questions: Question[];
+  };
+}
+
+export default function PublicSurveyForm({ survey }: Props) {
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  const handleChange = (key: string, value: string | string[]) => {
+    setAnswers(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setError('');
+    try {
+      const res = await fetch(`/api/surveys/${survey.id}/responses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers }),
+      });
+      if (res.ok) {
+        setStatus('success');
+        return;
+      }
+      const data = await res.json().catch(() => null);
+      setError(data?.error ? 'Error al enviar.' : 'Error inesperado');
+      setStatus('error');
+    } catch {
+      setError('Error al enviar.');
+      setStatus('error');
+    }
+  };
+
+  const resetForm = () => {
+    setAnswers({});
+  };
+
+  if (status === 'success') {
+    return <p className="text-center text-lg">¡Gracias!</p>;
+  }
+
+  const disabled = survey.questions.length === 0 || status === 'loading';
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+      {survey.questions.length === 0 && (
+        <p className="text-sm text-muted-foreground">Esta encuesta no tiene preguntas.</p>
+      )}
+      {survey.questions.map(q => {
+        const key = q.id ?? `q${q.order}`;
+        return (
+          <Fieldset key={key} className="space-y-2">
+            <legend className="font-medium">
+              {q.label}
+              {q.required && <span className="ml-1 text-xs text-red-400">*</span>}
+            </legend>
+            {q.type === 'SHORT_TEXT' && (
+              <Input
+                id={key}
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              />
+            )}
+            {q.type === 'LONG_TEXT' && (
+              <Textarea
+                id={key}
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              />
+            )}
+            {q.type === 'EMAIL' && (
+              <Input
+                id={key}
+                type="email"
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              />
+            )}
+            {q.type === 'PHONE' && (
+              <Input
+                id={key}
+                type="tel"
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              />
+            )}
+            {q.type === 'DATE' && (
+              <Input
+                id={key}
+                type="date"
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              />
+            )}
+            {q.type === 'SINGLE_CHOICE' && (
+              <Select
+                id={key}
+                value={(answers[key] as string) || ''}
+                onChange={e => handleChange(key, e.target.value)}
+                disabled={status === 'loading'}
+              >
+                <option value="">Selecciona…</option>
+                {q.options?.map(o => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+            )}
+            {q.type === 'MULTIPLE_CHOICE' && (
+              <div className="space-y-2">
+                {q.options?.map(o => {
+                  const arr = (answers[key] as string[] | undefined) || [];
+                  const checked = Array.isArray(arr) && arr.includes(o.value);
+                  return (
+                    <label key={o.value} className="flex items-center gap-2">
+                      <Input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={e => {
+                          const prev: string[] = Array.isArray(arr) ? arr : [];
+                          if (e.target.checked) {
+                            handleChange(key, [...prev, o.value]);
+                          } else {
+                            handleChange(key, prev.filter(v => v !== o.value));
+                          }
+                        }}
+                        disabled={status === 'loading'}
+                      />
+                      <span>{o.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            {q.helpText && <p className="text-xs text-muted-foreground">{q.helpText}</p>}
+          </Fieldset>
+        );
+      })}
+      <div className="flex gap-2 pt-4">
+        <Button type="submit" disabled={disabled}>
+          {status === 'loading' ? 'Enviando…' : 'Enviar'}
+        </Button>
+        <Button type="button" variant="muted" onClick={resetForm} disabled={status === 'loading'}>
+          Limpiar
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/modules/survey/lib/validation.ts
+++ b/src/modules/survey/lib/validation.ts
@@ -68,7 +68,21 @@ export function buildZodFromSurvey(questions: Question[]) {
         break;
       }
       case 'DATE': {
-        schema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+        schema = z.string().refine(val => {
+          // Check format
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return false;
+          // Parse components
+          const [year, month, day] = val.split('-').map(Number);
+          const date = new Date(val + 'T00:00:00Z');
+          // Check that date is valid and matches input
+          return (
+            date instanceof Date &&
+            !isNaN(date.getTime()) &&
+            date.getUTCFullYear() === year &&
+            date.getUTCMonth() + 1 === month &&
+            date.getUTCDate() === day
+          );
+        }, { message: 'Invalid date' });
         break;
       }
       case 'SINGLE_CHOICE': {

--- a/tests/survey-public-api.test.ts
+++ b/tests/survey-public-api.test.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from '@survey/app/api/survey/[slug]/route';
+import { NextRequest } from 'next/server';
+import prisma from '@core/prisma';
+vi.mock('@core/prisma', () => ({
+  __esModule: true,
+  default: {
+    survey: { findUnique: vi.fn() },
+  },
+}));
+const mocked = prisma as unknown as { survey: { findUnique: any } };
+
+describe('GET /api/survey/[slug]', () => {
+  it('returns 404 when survey not published', async () => {
+    (mocked.survey.findUnique as any).mockResolvedValue({ status: 'DRAFT' });
+    const req = new NextRequest('http://localhost/api/survey/test');
+    const res = await GET(req, { params: { slug: 'test' } });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/survey-response-api.test.ts
+++ b/tests/survey-response-api.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '@survey/app/api/surveys/[id]/responses/route';
+import { NextRequest } from 'next/server';
+import { resetRateLimit } from '@survey/lib/rate-limit';
+import prisma from '@core/prisma';
+vi.mock('@core/prisma', () => ({
+  __esModule: true,
+  default: {
+    survey: { findUnique: vi.fn() },
+    surveyResponse: { create: vi.fn() },
+  },
+}));
+const mocked = prisma as unknown as {
+  survey: { findUnique: any };
+  surveyResponse: { create: any };
+};
+
+const survey = {
+  id: 's1',
+  status: 'PUBLISHED',
+  questions: [
+    { id: 'q1', type: 'SHORT_TEXT', label: 'Name', order: 0, required: true },
+  ],
+};
+
+describe('POST /api/surveys/[id]/responses', () => {
+  beforeEach(() => {
+    resetRateLimit();
+    (mocked.survey.findUnique as any).mockReset();
+    (mocked.surveyResponse.create as any).mockReset();
+  });
+
+  it('accepts valid payload', async () => {
+    (mocked.survey.findUnique as any).mockResolvedValue(survey);
+    const req = new NextRequest('http://localhost/api/surveys/s1/responses', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: 'John' } }),
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '1.1.1.1' },
+    });
+    const res = await POST(req, { params: { id: 's1' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+      expect((mocked.surveyResponse.create as any)).toHaveBeenCalled();
+  });
+
+  it('rejects invalid payload', async () => {
+    (mocked.survey.findUnique as any).mockResolvedValue(survey);
+    const req = new NextRequest('http://localhost/api/surveys/s1/responses', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: '' } }),
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '1.1.1.1' },
+    });
+    const res = await POST(req, { params: { id: 's1' } });
+    expect(res.status).toBe(422);
+  });
+
+  it('applies rate limiting', async () => {
+    (mocked.survey.findUnique as any).mockResolvedValue(survey);
+    const req1 = new NextRequest('http://localhost/api/surveys/s1/responses', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: 'John' } }),
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '2.2.2.2' },
+    });
+    const req2 = new NextRequest('http://localhost/api/surveys/s1/responses', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: 'John' } }),
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '2.2.2.2' },
+    });
+    await POST(req1, { params: { id: 's1' } });
+    const res2 = await POST(req2, { params: { id: 's1' } });
+    expect(res2.status).toBe(429);
+  });
+});

--- a/tests/survey-response-api.test.ts
+++ b/tests/survey-response-api.test.ts
@@ -41,7 +41,7 @@ describe('POST /api/surveys/[id]/responses', () => {
     const res = await POST(req, { params: { id: 's1' } });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-      expect((mocked.surveyResponse.create as any)).toHaveBeenCalled();
+    expect((mocked.surveyResponse.create as any)).toHaveBeenCalled();
   });
 
   it('rejects invalid payload', async () => {


### PR DESCRIPTION
## Summary
- build dynamic validation schema for public survey responses
- add public survey page and API routes
- test survey response submission and rate limiting

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `NODE_ENV=production npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afc915dec48320ac8f7347d12fa71f