### PR TITLE
feat(survey): add logout button

### DIFF
--- a/src/modules/survey/app/survey/layout.tsx
+++ b/src/modules/survey/app/survey/layout.tsx
@@ -1,17 +1,21 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
+import LogoutButton from '@survey/components/LogoutButton';
 
 export default function SurveyLayout({ children }: { children: ReactNode }) {
   return (
     <main className="mx-auto w-full max-w-[1400px] px-3 md:px-4 lg:px-6 py-5 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold tracking-tight">Encuestas</h1>
-        <Link
-          href="/survey/new"
-          className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500"
-        >
-          Nueva encuesta
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/survey/new"
+            className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500"
+          >
+            Nueva encuesta
+          </Link>
+          <LogoutButton />
+        </div>
       </div>
       {children}
     </main>

--- a/src/modules/survey/components/LogoutButton.tsx
+++ b/src/modules/survey/components/LogoutButton.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function LogoutButton() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await fetch('/api/logout', { method: 'POST' });
+    router.push('/login');
+  };
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-500"
+    >
+      Logout
+    </button>
+  );
+}

--- a/src/modules/survey/components/SurveyIndex.tsx
+++ b/src/modules/survey/components/SurveyIndex.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import LogoutButton from '@survey/components/LogoutButton';
 
 type SurveyItem = {
   id: string;
@@ -153,12 +154,15 @@ export default function SurveyIndex() {
             </div>
           </form>
 
-          <Link
-            href="/survey/new"
-            className="inline-flex shrink-0 items-center justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
-          >
-            Nueva encuesta
-          </Link>
+          <div className="flex gap-2">
+            <Link
+              href="/survey/new"
+              className="inline-flex shrink-0 items-center justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
+            >
+              Nueva encuesta
+            </Link>
+            <LogoutButton />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add reusable `LogoutButton` component
- integrate logout button beside "Nueva encuesta" controls in survey pages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afdba1ffd483208b5e35c8379a4ccb