### PR TITLE
Add raffle module with API and tests

### DIFF
--- a/prisma/migrations/0006_raffle/migration.sql
+++ b/prisma/migrations/0006_raffle/migration.sql
@@ -1,0 +1,43 @@
+-- Create Raffle table
+CREATE TABLE "Raffle" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "surveyId" TEXT NOT NULL UNIQUE,
+  "isActive" BOOLEAN NOT NULL DEFAULT false,
+  "publicParticipants" BOOLEAN NOT NULL DEFAULT true,
+  "publicDisplayQuestionIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT "Raffle_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Create RaffleEntry table
+CREATE TABLE "RaffleEntry" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "raffleId" TEXT NOT NULL,
+  "surveyResponseId" TEXT NOT NULL,
+  "phoneNorm" VARCHAR(32),
+  "ipHash" CHAR(64) NOT NULL,
+  "userAgentShort" VARCHAR(200),
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT "RaffleEntry_raffleId_fkey" FOREIGN KEY ("raffleId") REFERENCES "Raffle"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "RaffleEntry_surveyResponseId_fkey" FOREIGN KEY ("surveyResponseId") REFERENCES "SurveyResponse"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "RaffleEntry_raffleId_surveyResponseId_key" ON "RaffleEntry"("raffleId", "surveyResponseId");
+CREATE UNIQUE INDEX "RaffleEntry_raffleId_ipHash_key" ON "RaffleEntry"("raffleId", "ipHash");
+CREATE UNIQUE INDEX "RaffleEntry_raffleId_phoneNorm_key" ON "RaffleEntry"("raffleId", "phoneNorm");
+CREATE INDEX "RaffleEntry_raffleId_createdAt_idx" ON "RaffleEntry"("raffleId", "createdAt");
+
+-- Create RaffleWinner table
+CREATE TABLE "RaffleWinner" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "raffleId" TEXT NOT NULL,
+  "raffleEntryId" TEXT NOT NULL UNIQUE,
+  "position" INTEGER NOT NULL,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT "RaffleWinner_raffleId_fkey" FOREIGN KEY ("raffleId") REFERENCES "Raffle"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "RaffleWinner_raffleEntryId_fkey" FOREIGN KEY ("raffleEntryId") REFERENCES "RaffleEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "RaffleWinner_raffleId_position_key" ON "RaffleWinner"("raffleId", "position");
+CREATE INDEX "RaffleWinner_raffleId_idx" ON "RaffleWinner"("raffleId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Survey {
   updatedAt     DateTime         @updatedAt
   questions     SurveyQuestion[]
   responses     SurveyResponse[]
+  raffle        Raffle?
 }
 
 model SurveyQuestion {
@@ -69,6 +70,53 @@ model SurveyResponse {
   answers   Json
   completed Boolean  @default(true)
   createdAt DateTime @default(now())
+  raffleEntries RaffleEntry[]
+}
+
+model Raffle {
+  id                       String   @id @default(cuid())
+  surveyId                 String   @unique
+  survey                   Survey   @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  isActive                 Boolean  @default(false)
+  publicParticipants       Boolean  @default(true)
+  publicDisplayQuestionIds String[] @default([])
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
+
+  entries RaffleEntry[]
+  winners RaffleWinner[]
+}
+
+model RaffleEntry {
+  id               String   @id @default(cuid())
+  raffleId         String
+  raffle           Raffle   @relation(fields: [raffleId], references: [id], onDelete: Cascade)
+  surveyResponseId String
+  surveyResponse   SurveyResponse @relation(fields: [surveyResponseId], references: [id], onDelete: Cascade)
+
+  phoneNorm      String?  @db.VarChar(32)
+  ipHash         String   @db.Char(64)
+  userAgentShort String?  @db.VarChar(200)
+  createdAt      DateTime @default(now())
+
+  @@unique([raffleId, surveyResponseId])
+  @@unique([raffleId, ipHash])
+  @@unique([raffleId, phoneNorm])
+  @@index([raffleId, createdAt])
+  winner        RaffleWinner?
+}
+
+model RaffleWinner {
+  id            String   @id @default(cuid())
+  raffleId      String
+  raffle        Raffle   @relation(fields: [raffleId], references: [id], onDelete: Cascade)
+  raffleEntryId String   @unique
+  raffleEntry   RaffleEntry @relation(fields: [raffleEntryId], references: [id], onDelete: Cascade)
+  position      Int
+  createdAt     DateTime @default(now())
+
+  @@unique([raffleId, position])
+  @@index([raffleId])
 }
 
 enum SurveyStatus {

--- a/src/app/api/raffles/[id]/draw/route.ts
+++ b/src/app/api/raffles/[id]/draw/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@raffle/app/api/raffles/[id]/draw/route';

--- a/src/app/api/raffles/[id]/export.csv/route.ts
+++ b/src/app/api/raffles/[id]/export.csv/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@raffle/app/api/raffles/[id]/export.csv/route';

--- a/src/app/api/raffles/[id]/participants/route.ts
+++ b/src/app/api/raffles/[id]/participants/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@raffle/app/api/raffles/[id]/participants/route';

--- a/src/app/api/raffles/[id]/participate/route.ts
+++ b/src/app/api/raffles/[id]/participate/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@raffle/app/api/raffles/[id]/participate/route';

--- a/src/app/api/raffles/[id]/route.ts
+++ b/src/app/api/raffles/[id]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@raffle/app/api/raffles/[id]/route';

--- a/src/app/api/raffles/route.ts
+++ b/src/app/api/raffles/route.ts
@@ -1,0 +1,1 @@
+export { POST, GET } from '@raffle/app/api/raffles/route';

--- a/src/modules/raffle/app/api/raffles/[id]/draw/route.ts
+++ b/src/modules/raffle/app/api/raffles/[id]/draw/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { getSession } from '@core/api/auth';
+import { z } from 'zod';
+
+const DrawSchema = z.object({ count: z.number().int().min(1).max(100).optional() });
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = getSession(req);
+  if (!session || session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const raffle = await prisma.raffle.findUnique({
+    where: { id: params.id },
+  });
+  if (!raffle) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  const body = await req.json().catch(() => ({}));
+  const parse = DrawSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 });
+  }
+  const count = parse.data.count ?? 1;
+
+  const existingWinnerIds = await prisma.raffleWinner.findMany({
+    where: { raffleId: raffle.id },
+    select: { raffleEntryId: true },
+  });
+  const excluded = existingWinnerIds.map(w => w.raffleEntryId);
+  const entries = await prisma.raffleEntry.findMany({
+    where: { raffleId: raffle.id, id: { notIn: excluded } },
+    include: { surveyResponse: true },
+  });
+  if (entries.length === 0) {
+    return NextResponse.json({ error: 'No entries available' }, { status: 400 });
+  }
+  // shuffle
+  for (let i = entries.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [entries[i], entries[j]] = [entries[j], entries[i]];
+  }
+  const selected = entries.slice(0, count);
+  const maxPos = await prisma.raffleWinner.aggregate({
+    where: { raffleId: raffle.id },
+    _max: { position: true },
+  });
+  let position = (maxPos._max.position ?? 0) + 1;
+
+  const winnersData = selected.map(e => ({
+    raffleId: raffle.id,
+    raffleEntryId: e.id,
+    position: position++,
+  }));
+  await prisma.raffleWinner.createMany({ data: winnersData });
+
+  const winners = winnersData.map((w, idx) => {
+    const answers = selected[idx].surveyResponse.answers as Record<string, unknown>;
+    const preview: Record<string, unknown> = {};
+    for (const k of raffle.publicDisplayQuestionIds) {
+      preview[k] = answers[k];
+    }
+    return { position: w.position, raffleEntryId: w.raffleEntryId, publicPreview: preview };
+  });
+
+  return NextResponse.json({ ok: true, winners });
+}

--- a/src/modules/raffle/app/api/raffles/[id]/export.csv/route.ts
+++ b/src/modules/raffle/app/api/raffles/[id]/export.csv/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+import prisma from '@core/prisma';
+import { getSession } from '@core/api/auth';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = getSession(req);
+  if (!session || session.role !== 'ADMIN') {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const raffle = await prisma.raffle.findUnique({ where: { id: params.id } });
+  if (!raffle) return new Response('Not found', { status: 404 });
+
+  const entries = await prisma.raffleEntry.findMany({
+    where: { raffleId: raffle.id },
+    include: { surveyResponse: true },
+    orderBy: { createdAt: 'asc' },
+  });
+  const allKeys = new Set<string>();
+  entries.forEach(e => {
+    const ans = e.surveyResponse.answers as Record<string, unknown>;
+    Object.keys(ans).forEach(k => allKeys.add(k));
+  });
+  const headers = ['createdAt', 'ipHash', 'userAgentShort', ...Array.from(allKeys)];
+  const rows = entries.map(e => {
+    const ans = e.surveyResponse.answers as Record<string, unknown>;
+    const ipMasked = e.ipHash.slice(0, 6) + '***';
+    const row = [e.createdAt.toISOString(), ipMasked, e.userAgentShort ?? ''];
+    for (const k of allKeys) {
+      const val = ans[k as string];
+      row.push(typeof val === 'string' ? val : JSON.stringify(val ?? ''));
+    }
+    return row.join(',');
+  });
+  const csv = [headers.join(','), ...rows].join('\n');
+  return new Response(csv, {
+    headers: { 'Content-Type': 'text/csv' },
+  });
+}

--- a/src/modules/raffle/app/api/raffles/[id]/participants/route.ts
+++ b/src/modules/raffle/app/api/raffles/[id]/participants/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { getSession } from '@core/api/auth';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const raffle = await prisma.raffle.findUnique({ where: { id: params.id } });
+  if (!raffle) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const { searchParams } = req.nextUrl;
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '20', 10);
+
+  const entries = await prisma.raffleEntry.findMany({
+    where: { raffleId: raffle.id },
+    include: { surveyResponse: true },
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+    orderBy: { createdAt: 'desc' },
+  });
+  const total = await prisma.raffleEntry.count({ where: { raffleId: raffle.id } });
+
+  const session = getSession(req);
+  if (raffle.publicParticipants) {
+    const items = entries.map(e => {
+      const answers = e.surveyResponse.answers as Record<string, unknown>;
+      const picked: Record<string, unknown> = {};
+      for (const k of raffle.publicDisplayQuestionIds) {
+        picked[k] = answers[k];
+      }
+      return picked;
+    });
+    return NextResponse.json({ items, total, page, pageSize });
+  }
+
+  if (!session || (session.role !== 'ADMIN' && session.role !== 'DJ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const items = entries.map(e => ({
+    id: e.id,
+    createdAt: e.createdAt,
+    userAgentShort: e.userAgentShort,
+    phoneNorm: e.phoneNorm,
+    surveyResponseId: e.surveyResponseId,
+    answers: e.surveyResponse.answers,
+  }));
+  return NextResponse.json({ items, total, page, pageSize });
+}

--- a/src/modules/raffle/app/api/raffles/[id]/participate/route.ts
+++ b/src/modules/raffle/app/api/raffles/[id]/participate/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { buildZodFromSurvey, normalizeAnswers, Question } from '@survey/lib/validation';
+import { phoneNormalizer, sha256Hex, isPhoneLike } from '@raffle/lib/utils';
+import { Prisma } from '@prisma/client';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const raffle = await prisma.raffle.findUnique({
+    where: { id: params.id },
+    include: { survey: { include: { questions: { orderBy: { order: 'asc' } } } } },
+  });
+  if (!raffle || !raffle.isActive) {
+    return NextResponse.json({ error: 'Raffle not active' }, { status: 404 });
+  }
+  const body = await req.json().catch(() => null);
+  const answers = body?.answers ?? {};
+  const questions = raffle.survey.questions as unknown as Question[];
+  const schema = buildZodFromSurvey(questions);
+  const parse = schema.safeParse(answers);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 422 });
+  }
+  const normalized = normalizeAnswers(parse.data, questions);
+
+  const response = await prisma.surveyResponse.create({
+    data: { surveyId: raffle.surveyId, answers: normalized as Prisma.InputJsonValue },
+  });
+
+  let phoneNorm: string | null = null;
+  for (const q of questions) {
+    const val = normalized[q.id ?? `q${q.order}`];
+    if (typeof val === 'string' && isPhoneLike(q.id || q.label)) {
+      phoneNorm = phoneNormalizer(val);
+      break;
+    }
+  }
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0] ?? req.ip ?? '0.0.0.0';
+  const ua = req.headers.get('user-agent') || '';
+  const ipHash = sha256Hex(`${ip}|${ua}`);
+  const userAgentShort = ua.slice(0, 200);
+
+  try {
+    await prisma.raffleEntry.create({
+      data: {
+        raffleId: raffle.id,
+        surveyResponseId: response.id,
+        phoneNorm: phoneNorm ?? undefined,
+        ipHash,
+        userAgentShort,
+      },
+    });
+  } catch (err) {
+    if (err && typeof err === 'object' && (err as Prisma.PrismaClientKnownRequestError).code === 'P2002') {
+      const e = err as Prisma.PrismaClientKnownRequestError;
+      const target = e.meta?.target as string[] | undefined;
+      if (target?.includes('ipHash')) {
+        return NextResponse.json({ error: 'Ya participaste desde este dispositivo.' }, { status: 409 });
+      }
+      if (target?.includes('phoneNorm')) {
+        return NextResponse.json({ error: 'Este teléfono ya está inscrito.' }, { status: 409 });
+      }
+    }
+    console.error('raffle participate error', err);
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/modules/raffle/app/api/raffles/[id]/route.ts
+++ b/src/modules/raffle/app/api/raffles/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { getSession } from '@core/api/auth';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const raffle = await prisma.raffle.findUnique({ where: { id: params.id } });
+  if (!raffle) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  const session = getSession(req);
+  if (!session) {
+    // public view
+    return NextResponse.json({
+      id: raffle.id,
+      surveyId: raffle.surveyId,
+      isActive: raffle.isActive,
+      publicParticipants: raffle.publicParticipants,
+      publicDisplayQuestionIds: raffle.publicDisplayQuestionIds,
+    });
+  }
+  return NextResponse.json(raffle);
+}

--- a/src/modules/raffle/app/api/raffles/route.ts
+++ b/src/modules/raffle/app/api/raffles/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@core/prisma';
+import { getSession } from '@core/api/auth';
+import { z } from 'zod';
+import type { Prisma } from '@prisma/client';
+
+const RaffleCreateSchema = z.object({
+  surveyId: z.string(),
+  isActive: z.boolean().optional(),
+  publicParticipants: z.boolean().optional(),
+  publicDisplayQuestionIds: z.array(z.string()).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const session = getSession(req);
+  if (!session || session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parse = RaffleCreateSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 });
+  }
+  const data = parse.data;
+  try {
+    const created = await prisma.raffle.create({
+      data: {
+        surveyId: data.surveyId,
+        isActive: data.isActive ?? false,
+        publicParticipants: data.publicParticipants ?? true,
+        publicDisplayQuestionIds: data.publicDisplayQuestionIds ?? [],
+      },
+    });
+    return NextResponse.json({ ok: true, data: created }, { status: 201 });
+  } catch (err) {
+    console.error('Create raffle error', err);
+    return NextResponse.json({ error: 'Database error' }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const session = getSession(req);
+  if (!session || session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = req.nextUrl;
+  const surveyId = searchParams.get('surveyId') || undefined;
+  const q = searchParams.get('q') || undefined;
+  const where: Prisma.RaffleWhereInput = {};
+  if (surveyId) where.surveyId = surveyId;
+  if (q) {
+    where.OR = [
+      { survey: { name: { contains: q, mode: 'insensitive' } } },
+      { survey: { slug: { contains: q, mode: 'insensitive' } } },
+    ];
+  }
+  const items = await prisma.raffle.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+  });
+  return NextResponse.json({ items });
+}

--- a/src/modules/raffle/lib/utils.ts
+++ b/src/modules/raffle/lib/utils.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'crypto';
+
+/** Normalize phone numbers: strip spaces/dashes, remove leading zeros, add +51 if no country code */
+export function phoneNormalizer(text: string): string {
+  let digits = text.replace(/[^0-9+]/g, '');
+  if (digits.startsWith('+')) {
+    digits = '+' + digits.slice(1).replace(/^0+/, '');
+  } else {
+    digits = digits.replace(/^0+/, '');
+    if (!digits.startsWith('51')) digits = '51' + digits;
+    digits = '+' + digits;
+  }
+  return digits;
+}
+
+/** Return SHA256 hex string for input */
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/** Simple helper to detect phone-like question ids or labels */
+export function isPhoneLike(questionIdOrLabel: string): boolean {
+  return /(tel|phone|cel)/i.test(questionIdOrLabel);
+}

--- a/src/modules/survey/app/public/survey/[id]/page.tsx
+++ b/src/modules/survey/app/public/survey/[id]/page.tsx
@@ -16,6 +16,7 @@ export default async function SurveyPublicPage({ params }: { params: { id: strin
     questions: Question[];
   }) | null;
   if (!survey || survey.status !== 'PUBLISHED') notFound();
+  const raffle = await prisma.raffle.findUnique({ where: { surveyId: survey.id } });
   return (
     <div className="mx-auto max-w-3xl p-4 sm:p-6">
       {/* Encabezado estilo Google Forms */}
@@ -30,6 +31,21 @@ export default async function SurveyPublicPage({ params }: { params: { id: strin
       <Card>
         <PublicSurveyForm survey={survey} />
       </Card>
+      {raffle && raffle.isActive && (
+        <form
+          action={`/api/raffles/${raffle.id}/participate`}
+          method="post"
+          className="mt-4 text-center"
+        >
+          <input type="hidden" name="fromSurvey" value="1" />
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+          >
+            Participar
+          </button>
+        </form>
+      )}
     </div>
   );
 }

--- a/tests/raffle-api.test.ts
+++ b/tests/raffle-api.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST as participate } from '@raffle/app/api/raffles/[id]/participate/route';
+import { POST as draw } from '@raffle/app/api/raffles/[id]/draw/route';
+import { NextRequest } from 'next/server';
+import prisma from '@core/prisma';
+
+vi.mock('@core/prisma', () => ({
+  __esModule: true,
+  default: {
+    raffle: { findUnique: vi.fn() },
+    surveyResponse: { create: vi.fn() },
+    raffleEntry: { create: vi.fn(), findMany: vi.fn() },
+    raffleWinner: {
+      findMany: vi.fn(),
+      aggregate: vi.fn(),
+      createMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@core/api/auth', () => ({
+  getSession: vi.fn(() => ({ role: 'ADMIN', sub: '1' })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mocked = prisma as any;
+
+const raffle = {
+  id: 'r1',
+  surveyId: 's1',
+  isActive: true,
+  publicParticipants: true,
+  publicDisplayQuestionIds: ['q1'],
+  survey: {
+    id: 's1',
+    questions: [
+      { id: 'q1', type: 'PHONE', label: 'Teléfono', order: 0, required: true },
+    ],
+  },
+};
+
+describe('raffle participate', () => {
+  beforeEach(() => {
+    mocked.raffle.findUnique.mockResolvedValue(raffle);
+    mocked.surveyResponse.create.mockResolvedValue({ id: 'sr1' });
+    mocked.raffleEntry.create.mockReset();
+  });
+
+  it('accepts first participation', async () => {
+    mocked.raffleEntry.create.mockResolvedValue({ id: 'e1' });
+    const req = new NextRequest('http://localhost/api/raffles/r1/participate', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: '+51999111222' } }),
+      headers: { 'content-type': 'application/json', 'user-agent': 'UA', 'x-forwarded-for': '1.1.1.1' },
+    });
+    const res = await participate(req, { params: { id: 'r1' } });
+    expect(res.status).toBe(201);
+  });
+
+  it('blocks same device', async () => {
+    mocked.raffleEntry.create.mockRejectedValue({ code: 'P2002', meta: { target: ['ipHash'] } });
+    const req = new NextRequest('http://localhost/api/raffles/r1/participate', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: '+51999111222' } }),
+      headers: { 'content-type': 'application/json', 'user-agent': 'UA', 'x-forwarded-for': '1.1.1.1' },
+    });
+    const res = await participate(req, { params: { id: 'r1' } });
+    expect(res.status).toBe(409);
+  });
+
+  it('blocks same phone', async () => {
+    mocked.raffleEntry.create.mockRejectedValue({ code: 'P2002', meta: { target: ['phoneNorm'] } });
+    const req = new NextRequest('http://localhost/api/raffles/r1/participate', {
+      method: 'POST',
+      body: JSON.stringify({ answers: { q1: '+51999111222' } }),
+      headers: { 'content-type': 'application/json', 'user-agent': 'UA', 'x-forwarded-for': '1.1.1.1' },
+    });
+    const res = await participate(req, { params: { id: 'r1' } });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('raffle draw', () => {
+  beforeEach(() => {
+    mocked.raffle.findUnique.mockResolvedValue({ ...raffle, publicDisplayQuestionIds: [] });
+    mocked.raffleWinner.findMany.mockResolvedValue([]);
+    mocked.raffleEntry.findMany.mockResolvedValue([
+      { id: 'e1', surveyResponse: { answers: { q1: 'A' } } },
+      { id: 'e2', surveyResponse: { answers: { q1: 'B' } } },
+    ]);
+    mocked.raffleWinner.aggregate.mockResolvedValue({ _max: { position: null } });
+    mocked.raffleWinner.createMany.mockResolvedValue({});
+  });
+
+  it('draws winners', async () => {
+    const req = new NextRequest('http://localhost/api/raffles/r1/draw', {
+      method: 'POST',
+      body: JSON.stringify({ count: 2 }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await draw(req, { params: { id: 'r1' } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.winners).toHaveLength(2);
+    expect(mocked.raffleWinner.createMany).toHaveBeenCalled();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,9 @@
       ],
       "@survey/*": [
         "./src/modules/survey/*"
+      ],
+      "@raffle/*": [
+        "./src/modules/raffle/*"
       ]
     },
     "incremental": true,


### PR DESCRIPTION
## Summary
- add Prisma models and migration for raffles, entries and winners
- implement raffle utilities and API endpoints for participation, drawing winners and listing participants
- wire up public survey page with raffle participation button and provide tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0986941188320801f2eea971085cb